### PR TITLE
Fix error occurring when attaching a file to a Task

### DIFF
--- a/db/files.go
+++ b/db/files.go
@@ -11,8 +11,12 @@ import (
 
 // AddFile is used to add the md5 of a file name which is uploaded to our application
 // this will enable us to randomize the URL without worrying about the file names
-func AddFile(fileName, token string) error {
-	err := taskQuery("insert into files values(?,?)", fileName, token)
+func AddFile(fileName, token, username string) error {
+	userID, err := GetUserID(username)
+	if err != nil {
+		return err
+	}
+	err = taskQuery("insert into files values(?,?,?,datetime())", fileName, token, userID)
 	return err
 }
 

--- a/db/files.go
+++ b/db/files.go
@@ -11,8 +11,8 @@ import (
 
 // AddFile is used to add the md5 of a file name which is uploaded to our application
 // this will enable us to randomize the URL without worrying about the file names
-func AddFile(fileName, token string) error {
-	err := taskQuery("insert into files values(?,?)", fileName, token)
+func AddFile(fileName, token, username string) error {
+	err := taskQuery("insert into files values(?,?,?,datetime())", fileName, token, username)
 	return err
 }
 

--- a/db/files.go
+++ b/db/files.go
@@ -12,7 +12,11 @@ import (
 // AddFile is used to add the md5 of a file name which is uploaded to our application
 // this will enable us to randomize the URL without worrying about the file names
 func AddFile(fileName, token, username string) error {
-	err := taskQuery("insert into files values(?,?,?,datetime())", fileName, token, username)
+	userID, err := GetUserID(username)
+	if err != nil {
+		return err
+	}
+	err = taskQuery("insert into files values(?,?,?,datetime())", fileName, token, userID)
 	return err
 }
 

--- a/views/addViews.go
+++ b/views/addViews.go
@@ -72,6 +72,7 @@ func AddTaskFunc(w http.ResponseWriter, r *http.Request) {
 
 		cookie, _ := r.Cookie("csrftoken")
 		if formToken == cookie.Value {
+			username := sessions.GetCurrentUserName(r)
 			if handler != nil {
 				// this will be executed whenever a file is uploaded
 				r.ParseMultipartForm(32 << 20) //defined maximum size of file
@@ -95,13 +96,12 @@ func AddTaskFunc(w http.ResponseWriter, r *http.Request) {
 				}
 				content = content + filelink
 
-				fileTruth := db.AddFile(handler.Filename, token)
+				fileTruth := db.AddFile(handler.Filename, token, username)
 				if fileTruth != nil {
 					message = "Error adding filename in db"
 					log.Println("error adding task to db")
 				}
 			}
-			username := sessions.GetCurrentUserName(r)
 			taskTruth := db.AddTask(title, content, category, taskPriority, username)
 
 			if taskTruth != nil {


### PR DESCRIPTION
https://github.com/thewhitetulip/Tasks/issues/18 Extend the SQL storing the information to a file by username and creation date.

The SQL storing the information about an attached file was missing the values for the _user_id_ and _creation_date_.

This pull request extends the SQL by these two values.
